### PR TITLE
Compatibility fix for utils.sh script

### DIFF
--- a/build/utils.sh
+++ b/build/utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 BUILD_DIR="$(realpath $(dirname "${BASH_SOURCE[0]}"))"
 REPO_DIR="$(dirname "${BUILD_DIR}")"


### PR DESCRIPTION
Fixed a distro compatibility fix in utils.sh shebang (using NixOS for example), it is now using /usr/bin/env