### PR TITLE
Fix that ludicrous attempt at a Spanish translation

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -4,13 +4,14 @@
 #
 # Translators:
 # Dustin Falgout <dustin@falgout.us>, 2016
+# Adolfo Jayme Barrientos <fitojb@ubuntu.com>, 2017
 msgid ""
 msgstr ""
 "Project-Id-Version: Antergos\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-03 05:51-0600\n"
-"PO-Revision-Date: 2016-12-10 08:55+0000\n"
-"Last-Translator: Dustin Falgout <dustin@falgout.us>\n"
+"PO-Revision-Date: 2017-11-25 18:31-0600\n"
+"Last-Translator: Adolfo Jayme Barrientos <fitojb@ubuntu.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/faidoc/antergos/language/es/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -20,22 +21,20 @@ msgstr ""
 
 #: src/greeter.c:135
 msgid "Greeter Theme Error Detected"
-msgstr "Greeter tema Error detectado"
+msgstr "Se detectó un error en el tema de la pantalla recibidora"
 
 #: src/greeter.c:138
 msgid "Load _Default Theme"
-msgstr "Carga _Default tema"
+msgstr "Cargar tema pre_determinado"
 
 #: src/greeter.c:140
 msgid "Load _Fallback Theme"
-msgstr "Tema de _Fallback de carga"
+msgstr "Cargar tema de _reserva"
 
 #: src/greeter.c:142
 msgid "_Cancel"
 msgstr "_Cancelar"
 
 #: src/greeter.c:151
-msgid ""
-"An error was detected in the current theme that could interfere with the "
-"system login process."
-msgstr "Se detectó un error en el tema actual que pudiera interferir con el proceso de inicio de sesión del sistema."
+msgid "An error was detected in the current theme that could interfere with the system login process."
+msgstr "Se detectó un error en el tema actual que puede interferir con el proceso de acceso al sistema."


### PR DESCRIPTION
Sorry for using GitHub, but I can’t stand Transifex’s UI. And you can delete those empty, country-specific files: there is nothing in this file which won’t be understood by all the Hispanophone world.