### PR TITLE
Fix meson build with a build directory other than 'build'

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -9,7 +9,7 @@ extdir = with_webext_dir[0]
 
 gresources_dir = include_directories('gresource')
 gnome = import('gnome')
-utils = '@0@/utils.sh'.format(meson.build_root())
+utils = join_paths(meson.source_root(), 'build/utils.sh')
 
 # Can't do it the right way until GLib 2.52 is released
 # js_sources = run_command(utils, 'get-js-files').stdout().split()


### PR DESCRIPTION
Building fails if the build directory is anything other than ./build
relative to the source root directory, e.g.

$ meson _build
[...]
src/meson.build:24:0: ERROR: Program or command '/lightdm-webkit2-greeter/_build/utils.sh' not found or not executable

Construct the absolute path to utils.sh in the source using join_paths and
meson.source_root()