### PR TITLE
utils.sh - Find fixed python binary using env instead

### DIFF
--- a/build/utils.sh
+++ b/build/utils.sh
@@ -33,7 +33,7 @@ do_build() {
 		&& zip -rq ../"${PKGNAME}.zip" . -x '**__pycache__**' 'resources/*' \
 		&& cd - >/dev/null \
 		&& mkdir -p "${INSTALL_ROOT}${PREFIX}"/{bin,share} \
-		&& echo '#!/bin/python3' >> "${INSTALL_ROOT}${PREFIX}/bin/web-greeter" \
+		&& echo '#!/usr/bin/env python3' >> "${INSTALL_ROOT}${PREFIX}/bin/web-greeter" \
 		&& cat web-greeter.zip >> "${INSTALL_ROOT}${PREFIX}/bin/web-greeter" \
 		&& chmod +x "${INSTALL_ROOT}${PREFIX}/bin/web-greeter")
 }


### PR DESCRIPTION
Because I'm feeling guilty for raising so many issues, and this is such an easy patch to write...

This intends to fix #160 .